### PR TITLE
fix: Se corrige la forma en la que se muestra el precio descuento y se aplican restricciones y valores por defecto para descuento [Padilla Santiago]

### DIFF
--- a/src/assets/components/ProductForm.jsx
+++ b/src/assets/components/ProductForm.jsx
@@ -5,7 +5,7 @@ const FormularioProducto = ({ alAgregarProducto }) => {
     id: crypto.randomUUID().slice(0, 6), // crea un ID único de 6 caracteres
     descripcion: "",
     precioUnitario: "",
-    descuento: "",
+    descuento: "0",
     precioConDescuento: "",
     stock: "",
   });
@@ -53,7 +53,7 @@ const FormularioProducto = ({ alAgregarProducto }) => {
       id: crypto.randomUUID().slice(0, 6),
       descripcion: "",
       precioUnitario: "",
-      descuento: "",
+      descuento: "0",
       precioConDescuento: "",
       stock: "",
     });
@@ -90,22 +90,21 @@ const FormularioProducto = ({ alAgregarProducto }) => {
           name="descuento"
           value={datosFormulario.descuento}
           onChange={manejarCambio}
+          min="0" // se asegura de que el descuento no sea negativo
+          max="100" // se asegura de que el descuento no sea mayor a 100
         />
       </div>
       <div>
         <label>Precio con Descuento:</label>
-        <input
-          type="number"
-          name="precioConDescuento"
-          value={
+        <span> $ 
+          { // se asegura de que el precio con descuento solo se muestre si hay un precio unitario y un descuento
             datosFormulario.precioUnitario &&
             datosFormulario.descuento
               ? datosFormulario.precioUnitario *
                 (1 - datosFormulario.descuento / 100)
               : ""
           }
-          readOnly
-        />
+        </span>
       </div>
       <div>
         <label>Stock:</label>


### PR DESCRIPTION
- Se aplica por default un valor para descuento igual a 0 que significaría sin descuento
- Cuando se limpia el formulario se establece que en el campo descuento por defecto empiece con el valor 0
- Se establece un mínimo y un máximo para el valor de descuento
- Se cambia la forma en la que se muestra el precioConDescuento ( Antes un input no modificable -> Ahora un span donde se realiza el mismo calculo que se realizaba antes en el input